### PR TITLE
Add command for creating Stats classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,9 @@
 
 This package is a lightweight solution to summarize changes in your database over time. Here's a quick example where we are going to track the number of subscriptions and cancellations over time.
 
-First, you should create a stats class.
-
-```php
-use Spatie\Stats\BaseStats;
-
-class SubscriptionStats extends BaseStats {}
+First, you should create a stats class:
+```bash
+php artisan make:stats SubscriptionStats
 ```
 
 Next, you can call `increase` on it when somebody subscribes, and `decrease` when somebody cancels their plan.

--- a/src/Console/StatsMakeCommand.php
+++ b/src/Console/StatsMakeCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Spatie\Stats\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+class StatsMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:stats';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new stats class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Stats';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub() : string
+    {
+        return __DIR__ . '/stubs/stats_class.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param string $rootNamespace The root namespace
+     *
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace) : string
+    {
+        return $rootNamespace . '\Stats';
+    }
+
+    /**
+     * @param string $stub
+     * @param string $name
+     *
+     * @return string
+     */
+    protected function replaceClass($stub, $name): string
+    {
+        if (!$this->argument('name')) {
+            throw new InvalidArgumentException("Missing required argument model name");
+        } else {
+            $name = $this->argument('name');
+            $stub = str_replace('DummyClass', $name, $stub);
+            $stub = str_replace('DummySlug', Str::slug(Str::headline($name)), $stub);
+        }
+        return $stub;
+    }
+}

--- a/src/Console/stubs/stats_class.stub
+++ b/src/Console/stubs/stats_class.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace DummyNamespace;
+
+use Spatie\Stats\BaseStats;
+
+class DummyClass extends BaseStats
+{
+    /*
+    public function getName() : string {
+        return 'DummySlug'; // stats will be stored with using name `DummySlug`
+    }
+    */
+}

--- a/src/StatsServiceProvider.php
+++ b/src/StatsServiceProvider.php
@@ -4,6 +4,7 @@ namespace Spatie\Stats;
 
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\Stats\Console\StatsMakeCommand;
 
 class StatsServiceProvider extends PackageServiceProvider
 {
@@ -11,6 +12,7 @@ class StatsServiceProvider extends PackageServiceProvider
     {
         $package
             ->name('stats')
-            ->hasMigration('create_stats_tables');
+            ->hasMigration('create_stats_tables')
+            ->hasCommand(StatsMakeCommand::class);
     }
 }


### PR DESCRIPTION
Make it easier for developers to make Stats classes with a single command:
```bash
php artisan make:stats SubscriptionStats
```