### PR TITLE
Add table prefix to StatsQuery

### DIFF
--- a/src/StatsQuery.php
+++ b/src/StatsQuery.php
@@ -278,7 +278,7 @@ class StatsQuery
     protected function getStatsTableName(): string
     {
         if ($this->subject instanceof Relation) {
-            return $this->subject->getRelated()->getTable();
+            return $this->subject->getQuery()->getGrammar()->getTablePrefix().$this->subject->getRelated()->getTable();
         }
 
         /** @var Model $subject */
@@ -287,6 +287,6 @@ class StatsQuery
             $subject = new $subject;
         }
 
-        return $subject->getTable();
+        return $subject->getQuery()->getGrammar()->getTablePrefix().$subject->getTable();
     }
 }

--- a/tests/StatsQueryTablePrefixTest.php
+++ b/tests/StatsQueryTablePrefixTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Spatie\Stats\Tests;
+
+use Carbon\Carbon;
+use Spatie\Stats\Tests\TestClasses\Models\Stat;
+
+class StatsQueryTablePrefixTest extends TestCase
+{
+    const PREFIXED_CONNECTION = 'prefixed';
+    const PREFIX = 'test_';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpPrefixedConnection();
+        Carbon::setTestNow('2020-01-01');
+    }
+
+    /** @test */
+    public function it_can_retrieve_a_table_prefix_of_a_model()
+    {
+        $subject = (new Stat())->setConnection(self::PREFIXED_CONNECTION);
+        $this->assertEquals($subject->getQuery()->getGrammar()->getTablePrefix(), self::PREFIX);
+    }
+
+    /** @test */
+    public function it_can_retrieve_a_table_prefix_of_a_relation()
+    {
+        $subject = (new Stat())->setConnection(self::PREFIXED_CONNECTION);
+        $this->assertEquals($subject->events()->getQuery()->getGrammar()->getTablePrefix(), self::PREFIX);
+    }
+
+    protected function setUpPrefixedConnection()
+    {
+        $this->app['config']->set('database.connections.'.self::PREFIXED_CONNECTION, $this->app['config']->get('database.connections.mysql'));
+        $this->app['config']->set('database.connections.'.self::PREFIXED_CONNECTION.'.prefix', self::PREFIX);
+    }
+}


### PR DESCRIPTION
Fixes [#21](https://github.com/spatie/laravel-stats/issues/21)

When using `selectRaw` table names need to be prefixed when the database connection uses a `prefix` (config/database.php)

I've added tests for it, but I'm not sure they are how you would test it.